### PR TITLE
Build Multiarch Images

### DIFF
--- a/.github/workflows/auto-assign-issues.yaml
+++ b/.github/workflows/auto-assign-issues.yaml
@@ -1,0 +1,16 @@
+name: Issue assignment
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: "Auto-assign issue"
+        uses: pozil/auto-assign-issue@v1
+        with:
+          assignees: tuxpeople

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -47,24 +47,49 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: nelonoel/branch-name@v1.0.1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.1.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+      - name: set tags
+        id: set-tags
+        run: |
+          IMAGENAME=$(echo ${{ github.repository }} | sed 's/${{ github.repository_owner }}\///g')
+          if [ "${{ github.ref }}" == "refs/heads/master" ] && [ "${{ github.event_name }}" == "push" ]; then
+            VERSION="${{ env.BRANCH_NAME }}"
+            TAGS="ghcr.io/${{ github.repository_owner }}/${IMAGENAME}:${VERSION}"
+          elif  [ "${{ github.ref }}" == "refs/tags/v* "] && [ "${{ github.event_name }}" == "push" ]; then
+            VERSION="${GITHUB_REF##*/}"
+            TAGS="ghcr.io/${{ github.repository_owner }}/${IMAGENAME}:latest,ghcr.io/${{ github.repository_owner }}/${IMAGENAME}:${VERSION}"
+          fi
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=imagename::${IMAGENAME}
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build Docker image
-        run: docker build . --tag ghcr.io/brennerm/uptimerobot-operator:${{ env.BRANCH_NAME }}
-      - name: Push Docker image for branch
-        if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
-        run: docker push ghcr.io/brennerm/uptimerobot-operator:${{ env.BRANCH_NAME }}
-      - name: Push Docker image for tag
-        if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push' }}
-        run: |
-          docker tag ghcr.io/brennerm/uptimerobot-operator:${{ env.BRANCH_NAME }} ghcr.io/brennerm/uptimerobot-operator:latest
-          docker tag ghcr.io/brennerm/uptimerobot-operator:${{ env.BRANCH_NAME }} ghcr.io/brennerm/uptimerobot-operator:${GITHUB_REF##*/}
-          docker push ghcr.io/brennerm/uptimerobot-operator:latest
-          docker push ghcr.io/brennerm/uptimerobot-operator:${GITHUB_REF##*/}
+        id: docker_build
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: "linux/amd64,linux/arm/v7,linux/arm/v6,linux/arm64"
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.set-tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=${{ steps.set-tags.outputs.imagename }}
+            org.opencontainers.image.description=${{ github.event.repository.description }}
+            org.opencontainers.image.url=${{ github.event.repository.html_url }}
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.version=${{ steps.set-tags.outputs.version }}
+            org.opencontainers.image.created=${{ steps.set-tags.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
 
   build_helm_chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8.5"
+          python-version: "3.8.16"
       - name: Install dependencies
         run: |
           pip install pipenv

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -62,12 +62,12 @@ jobs:
             VERSION="${GITHUB_REF##*/}"
             TAGS="ghcr.io/${{ github.repository_owner }}/${IMAGENAME}:latest,ghcr.io/${{ github.repository_owner }}/${IMAGENAME}:${VERSION}"
           fi
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=imagename::${IMAGENAME}
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "imagename=${IMAGENAME}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV KOPF_OPTS="--all-namespaces"
 RUN pip install pipenv
 WORKDIR /app
 ADD Pipfile /app
-RUN pipenv lock --keep-outdated --requirements > requirements.txt
+RUN pipenv lock; pipenv requirements > requirements.txt
 RUN apk --update add gcc build-base
 RUN pip install -r requirements.txt
 ADD ur_operator /app/ur_operator


### PR DESCRIPTION
The main reason for this PR is to fix #27 as I'm need arm images ;-)

This PR consists of four changes:

- Changed Dockerfile's usage of pipenv, as I wasn't able to build the image the way pipenv was used (unknown argument), see commit https://github.com/brennerm/uptimerobot-operator/commit/53bf269a5d19a4c0d1a7740954a3302ed44b77a1
- I discovered that Python 3.8.5 was not longer available to install in the pipeline, hence I needed to bump it to 3.8.16, see commit https://github.com/brennerm/uptimerobot-operator/commit/7ade129194df83c9c25819d29b6db87301e5833a
- This is the main thing, using QEMU and BuildX to build multiple architectures. See commit https://github.com/brennerm/uptimerobot-operator/commit/4b31c174800f07bb9d3adae3ce4d2605d19c615e and further explanations below this summary
- As the above commit uses a deprecated way to share output between steps, I replaced that with the new way things should work in commit https://github.com/brennerm/uptimerobot-operator/commit/7b58ccb99d5101276467bffe4cec8e10bc9814ab to make sure it will still work after June 1st (see Githubs blog post [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)) and I bumped the login action to v2 because I hat issues (but the issues have been caused by something else, so change that back if you want)

About the changes of the commit https://github.com/brennerm/uptimerobot-operator/commit/4b31c174800f07bb9d3adae3ce4d2605d19c615e

I replaced the `docker build` step and the two `docker push` steps with the `build-push-action` from Docker. This action can do both in one, and also supports multiple architectures. For the multiple architectures to work, the `setup-qemu-action` and `setup-buildx-action` are necessary (Lines 50-53).

To replicate the former behavior of the two push steps, I created the step `set tags` (Line 54-68) which should eventually output the same tags as before. 

What's included but not absolutely necessary:
- I replaced `${{ secrets.CR_PAT }}` with `${{ secrets.GITHUB_TOKEN }}` as that token is default available and can be used to push stuff into ghcr.io and I was to lazy to create an additional token.
- The labels (Line 84ff) are not mandatory, but I used to label my images and I copied that from one of my workflows.

Feel free to revert those two things if you don't like them.

In general, I tried to stick as close as possible to what already existed. Therefore I (mostly) avoided bumping actions to newer versions or the bump the base image to a newer version. These are things you should consider, as some stuff is quite outdated.

I'm no Python developer, so I hope my pipenv changes are okay. At least the container was building and I was able to spin it up on a K3S on ARM here. But I wasn't able to perform the E2E tests from your pipeline, although I added my API key.

Hope that PR is okay, otherwise please let me know if you wish changes to it.  